### PR TITLE
(fix): add semicolon to avoid syntax error in snowsight

### DIFF
--- a/00_ingestion/copy_into.sql
+++ b/00_ingestion/copy_into.sql
@@ -2,7 +2,7 @@
 
 -- Specify the file format below:
 CREATE OR REPLACE STAGE tasty_bytes.public.s3load
-url = 's3://sfquickstarts/tasty-bytes-builder-education/'
+url = 's3://sfquickstarts/tasty-bytes-builder-education/';
 
 -- country table build
 CREATE OR REPLACE TABLE tasty_bytes.raw_pos.country


### PR DESCRIPTION
Added semicolon in the script to avoid syntax error while running it in Snowsight