### PR TITLE
2025-04-30: Update load_tasty_bytes.sql for Northstar Workshop

### DIFF
--- a/00_ingestion/load_tasty_bytes.sql
+++ b/00_ingestion/load_tasty_bytes.sql
@@ -296,12 +296,12 @@ FROM @tasty_bytes.public.s3load/raw_customer/customer_loyalty/;
 
 -- order_header table load
 COPY INTO tasty_bytes.raw_pos.order_header
-FROM @tasty_bytes.public.s3load/raw_pos/subset_order_header/;
+FROM @tasty_bytes.public.s3load/raw_pos/order_header/;
 
 
 -- order_detail table load
 COPY INTO tasty_bytes.raw_pos.order_detail
-FROM @tasty_bytes.public.s3load/raw_pos/subset_order_detail/;
+FROM @tasty_bytes.public.s3load/raw_pos/order_detail/;
 
 
 DROP WAREHOUSE demo_build_wh;


### PR DESCRIPTION
Repointed copy into statements for order_header and order_detail to the full data sets rather than the subsets. The subsets did not include any orders from the trucks in germany.